### PR TITLE
SKILL.md: Make quota error handling explicit

### DIFF
--- a/finlab-plugin/skills/finlab/SKILL.md
+++ b/finlab-plugin/skills/finlab/SKILL.md
@@ -55,11 +55,12 @@ is_free = token.endswith('#free')
 
 ### 用量超限處理
 
-當用戶遇到用量超限錯誤時，告知：
-- 今日用量已達上限（免費版 500 MB）
-- 台灣時間早上 8 點會自動重置
-- 升級 VIP 可享 5000 MB 額度（10 倍）
-- 升級連結：https://www.finlab.finance/payment
+當出現 `Usage exceed 500 MB/day` 或類似用量超限錯誤時，**主動**告知用戶：
+
+1. 今日用量已達上限（免費版 500 MB）
+2. 台灣時間早上 8 點會自動重置
+3. 升級 VIP 可享 5000 MB 額度（10 倍）
+4. 升級連結：https://www.finlab.finance/payment
 
 ### 回測報告格式
 


### PR DESCRIPTION
## The Problem

The docs were passive. They said "告知" (inform) but:
- Didn't tell the AI WHEN to trigger (no error string)
- Didn't say to be PROACTIVE

Result: AI just dumps the error and waits for user to ask "what now?"

## The Fix

Three changes:
1. Added exact error string: `Usage exceed 500 MB/day`
2. Changed "告知" to "**主動**告知" (proactively inform)
3. Numbered the steps (easier to follow)

That's it. No over-engineering.

## Feedback Reference
- ID: 9419cac6-d5a3-4a39-ac8b-070b92ef3467
- Type: improvement
- Context: User hit 500MB limit, AI didn't proactively suggest upgrade

---

Note: The other feedback (a929c427) wants 80% warnings and "new user protection periods". Those require **package code changes**, not docs. Out of scope for this repo.