### PR TITLE
docs(readme): 加學習資源連結到量化交易旗艦頁

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ Auto-detects your CLI (Claude Code / Codex / Gemini), installs [uv](https://docs
 | Factor Examples | 60+ complete strategy examples |
 | Best Practices | Patterns, anti-patterns, tips |
 | ML Reference | Feature engineering, labels |
+
+## Learn more
+
+- [Quant trading guide (量化交易)](https://finlab.finance/tools/quant-trading): what quantitative trading is, a Taiwan-stock strategy backtester, and a platform comparison.
+- [Strategy research blog](https://finlab.finance/blog): backtest-verified Taiwan-stock strategy reports (CAGR, Sharpe, max drawdown).
+- Website: [finlab.finance](https://finlab.finance)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -28,3 +28,9 @@ curl -sSf https://ai.finlab.finance/install.sh | sh
 | Factor Examples | 60+ 完整策略範例 |
 | Best Practices | 模式、反模式、技巧 |
 | ML Reference | 特徵工程、標籤生成 |
+
+## 學習資源
+
+- [量化交易完整教學](https://finlab.finance/tools/quant-trading)：什麼是量化交易、台股策略回測器與平台比較。
+- [策略研究部落格](https://finlab.finance/blog)：經過回測驗證的台股策略報告（CAGR、夏普、最大回撤）。
+- 官方網站：[finlab.finance](https://finlab.finance)


### PR DESCRIPTION
在中英 README 末尾新增「Learn more／學習資源」區，連到官網：

- `finlab.finance/tools/quant-trading`（量化交易完整教學，錨文字「量化交易」）
- `finlab.finance/blog`（策略研究部落格）

**目的**：對 plugin 使用者提供實用延伸資源，同時把 GitHub 高權重頁面的 dofollow 連結指向官網「量化交易」頭部詞旗艦頁（SEO 外部訊號）。純文件改動，不影響程式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)